### PR TITLE
Update requirements.txt to include pypiwin32 for Windows startup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Run the script:
 py main.py
 ```
 
+To add BetterDiscordAutoInstaller to your startup apps:
+```bash
+py startup_manager.py
+```
+
 ### MacOS
 
 This repository contains two Python scripts for automatically installing BetterDiscord on macOS. The scripts provide two different installation methods: one for manual installation with a keyboard shortcut and another for automatic installation on startup.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ certifi==2024.7.4
 charset-normalizer==3.3.2
 idna==3.7
 urllib3==2.2.2
-
+pypiwin32=223


### PR DESCRIPTION
Pretty simple change - startup_manager.py requires an import of winshell which relies upon pypiwin32, and is not installed by default when you install winshell through pip.  I also inserted two lines in the readme just to provide clarity for potential Windows users who are not super familiar with navigating CLI interfaces so they could be made more acutely aware of the startup_manager.py script.