### PR TITLE
Add support for scoop installations

### DIFF
--- a/funcs.py
+++ b/funcs.py
@@ -8,7 +8,11 @@ def start_discord(discord_parent_path: str):
     script_working_dir = os.getcwd()
 
     os.chdir('c:/')
-    subprocess.Popen(f'{os.path.join(discord_parent_path, "Update.exe")} --processStart Discord.exe')
+    if 'scoop\\apps' in discord_parent_path:
+        latest_installed_discord_version = get_latest_installed_discord_folder_name(discord_parent_path)
+        subprocess.Popen(f'{os.path.join(discord_parent_path, latest_installed_discord_version, "Discord.exe")}', stdout=subprocess.DEVNULL)
+    else:
+        subprocess.Popen(f'{os.path.join(discord_parent_path, "Update.exe")} --processStart Discord.exe')
     os.chdir(script_working_dir)
 
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import json
+import shutil
 import logging
 import requests
 from funcs import *
@@ -29,6 +30,7 @@ if os.name != 'nt':
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format='(%(asctime)s) %(message)s')
 appdata = os.getenv('appdata')
+home = os.getenv('userprofile')
 localappdata = os.getenv('localappdata')
 
 SETTINGS_PATH = 'settings.json'
@@ -39,9 +41,15 @@ logger.info('BetterDiscordAutoInstaller v1.2.1\n')
 
 # default settings
 CURRENT_SETTINGS_VERSION = 3
-DISCORD_PARENT_PATH = f'{localappdata}/Discord'
+DISCORD_PARENT_PATH = f'{localappdata}\\Discord'
 LAST_INSTALLED_DISCORD_VERSION = None
 DISABLE_VERSION_CHECKING = False
+
+if shutil.which('scoop') is not None:
+    scoop_info = subprocess.run(['scoop', 'list', 'discord'], capture_output=True, text=True, shell=True).stdout.splitlines()
+    discord_line = next((line for line in scoop_info if line.startswith('discord ')), None)
+    if discord_line:
+        DISCORD_PARENT_PATH = f'{home}\\scoop\\apps\\discord\\current\\app'
 
 # try to load settings
 if os.path.exists(SETTINGS_PATH):
@@ -60,8 +68,8 @@ discord_path = os.path.join(DISCORD_PARENT_PATH, latest_installed_discord_versio
 
 # get discord location from user if it is invalid
 while True:
-    if not os.path.exists(os.path.join(DISCORD_PARENT_PATH, 'update.exe')):
-        logger.info(f'Discord was not found at "{DISCORD_PARENT_PATH}". Enter the path to folder with "Update.exe":')
+    if not os.path.exists(os.path.join(DISCORD_PARENT_PATH, 'Update.exe')) and not os.path.exists(os.path.join(discord_path, 'Discord.exe')):
+        logger.info(f'Discord was not found at "{DISCORD_PARENT_PATH}".\nEnter the path to folder with "Update.exe" for normal installations or full path of ~\\scoop\\apps\\discord\\current\\app for scoop installations:')
         DISCORD_PARENT_PATH = input('\n=> ')
         dump_settings()
     else:


### PR DESCRIPTION
[Scoop](https://github.com/ScoopInstaller/Scoop) provides [Discord Portable](https://github.com/portapps/discord-portable), which has a slightly different setup from normal installations.
   
Folder structure differs and has no Update.exe.

https://github.com/user-attachments/assets/760c01e8-dbb8-4055-8775-1045318fadad

