### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can just run this script and it would work. However, that's not ideal. We wa
 cd Projects/BetterDiscordAutoInstaller
 source venv/bin/activate
 pip install -r requirements.txt
-python3 macos/manual-installer-mac.py
+python3 manual-installer-mac.py
 ```
 > Reminder: You can update the manual-installer-mac.py code to give you more or less notifications. Feel free to update the local code according to your preferences.
 7. Update the directory and virtual enviornment name to whatever you used. This example cloned the repo to the "Projects" directory and named the virtual env "venv".

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This repository contains two Python scripts for automatically installing BetterD
 
 #### Installation
 
-Clone the repository and change directory:
+Clone the repository branch for macos and change directory:
 ```bash
-git clone https://github.com/Zwylair/BetterDiscordAutoInstaller
+git clone -b macos https://github.com/Zwylair/BetterDiscordAutoInstaller
 cd BetterDiscordAutoInstaller
 ```
 


### PR DESCRIPTION
- Changed the command to download the macos branch instead of the default repository

It was confusing to follow the instruction for macos when the clone command downloaded the repository for windows.