### PR TITLE
Reworked script workflow

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,10 @@ def main():
 
     logger.info(f'BetterDiscordAutoInstaller v{BDAI_SCRIPT_VERSION}')
 
+    logger.info('Checking for BetterDiscordAutoInstaller updates...')
+    if check_for_updates() and not funcs.DISABLE_BDAI_AUTOUPDATE:
+        run_updater()
+
     logger.info("Killing any running Discord processes...")
     kill_discord()
     time.sleep(2)
@@ -37,10 +41,6 @@ def main():
     except FileNotFoundError as e:
         logger.error(str(e))
         sys.exit(1)
-
-    logger.info('Checking for BetterDiscordAutoInstaller updates...')
-    if check_for_updates() and not funcs.DISABLE_BDAI_AUTOUPDATE:
-        run_updater()
 
     logger.info("Installing BetterDiscord...")
     install_betterdiscord(discord_path)

--- a/main.py
+++ b/main.py
@@ -11,9 +11,11 @@ def main():
 
     logger.info(f'BetterDiscordAutoInstaller v{BDAI_SCRIPT_VERSION}')
 
-    if check_for_updates() and not funcs.DISABLE_BDAI_AUTOUPDATE:
-        run_updater()
+    logger.info("Killing any running Discord processes...")
+    kill_discord()
+    time.sleep(2)
 
+    logger.info('Checking if Discord is installed and updated...')
     funcs.DISCORD_PARENT_PATH = find_discord_path()
     if not funcs.DISCORD_PARENT_PATH:
         logger.error("No valid Discord installation found.")
@@ -28,12 +30,7 @@ def main():
 
         if discord_core_folder == funcs.LAST_INSTALLED_DISCORD_VERSION and not funcs.DISABLE_DISCORD_VERSION_CHECKING:
             
-            logger.info("Restarting Discord...")
-            start_discord(funcs.DISCORD_PARENT_PATH)
-
-            logger.info("Discord is already up to date. No update needed. Exiting in 3 seconds...")
-            time.sleep(3)
-            sys.exit(0)
+            logger.info("Discord is up to date.")
 
         funcs.LAST_INSTALLED_DISCORD_VERSION = discord_core_folder
         dump_settings()
@@ -41,9 +38,9 @@ def main():
         logger.error(str(e))
         sys.exit(1)
 
-    logger.info("Killing any running Discord processes...")
-    kill_discord()
-    time.sleep(2)
+    logger.info('Checking for BetterDiscordAutoInstaller updates...')
+    if check_for_updates() and not funcs.DISABLE_BDAI_AUTOUPDATE:
+        run_updater()
 
     logger.info("Installing BetterDiscord...")
     install_betterdiscord(discord_path)

--- a/main.py
+++ b/main.py
@@ -27,6 +27,10 @@ def main():
         discord_path = os.path.join(funcs.DISCORD_PARENT_PATH, discord_core_folder)
 
         if discord_core_folder == funcs.LAST_INSTALLED_DISCORD_VERSION and not funcs.DISABLE_DISCORD_VERSION_CHECKING:
+            
+            logger.info("Restarting Discord...")
+            start_discord(funcs.DISCORD_PARENT_PATH)
+
             logger.info("Discord is already up to date. No update needed. Exiting in 3 seconds...")
             time.sleep(3)
             sys.exit(0)


### PR DESCRIPTION
The current flow of the script wont allow updates if Discord is already updated - but BD is not.
The script currently will skip past latest BD and only check 1. Discord is up to date and 2. If BDAI is up to date.

My reasoning is that BDAI should update regardless. Therefore I have proposed this flow:

1. Check for BDAI updates
2. Kill Discord
3. Check if Discord is updated
4. Install BetterDiscord (regardless - I'm not skilled enough to make it check if installed version match downloaded)
5. Start Discord

This fixed my BD install after today's big patch.