### PR TITLE
Add UV as Install/Run method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For macOS, the user can also choose to bind script to a keyboard shortcut to man
 ### Self update checks
 
 BDAI will check if it is up to date. You can disable autoupdate by changing the `disable_bdai_autoupdate`
-setting to `true` in the `settings.json` file (but you will still  receive a message that a new version
+setting to `true` in the `settings.json` file (but you will still receive a message that a new version
 has been released).
 
 ## Setup and Dependencies
@@ -46,6 +46,12 @@ has been released).
 - Run the script: `python main.py`
 
 To add BetterDiscordAutoInstaller to your startup apps: `python startup_manager.py`
+
+#### [UV](https://docs.astral.sh/uv/)
+  - Install the tool: `uv tool install git+https://github.com/Zwylair/BetterDiscordAutoInstaller`
+  - Run with: `bdai` (or `uvx bdai` if it wasn't added to PATH)
+    - It can easily be updated later with: `uv tool upgrade bdai`
+  - `[Optional]` Add to your startup with: `bdai --startup-manager` (`uvx bdai --startup-manager` if not in PATH)
 
 ### MacOS
 You need to go to [this](https://github.com/Zwylair/BetterDiscordAutoInstaller/tree/macos?tab=readme-ov-file#setup-and-dependencies) README.md

--- a/config/constants.py
+++ b/config/constants.py
@@ -6,12 +6,12 @@ APPDATA = os.getenv("appdata")
 LOCALAPPDATA = os.getenv("localappdata")
 USERPROFILE = os.getenv("userprofile")
 
-BDAI_SCRIPT_VERSION = "1.5.0"
+BDAI_SCRIPT_VERSION = "1.6.0"
 BDAI_LATEST_RELEASE_PAGE_URL = "https://github.com/Zwylair/BetterDiscordAutoInstaller/releases/latest"
 BDAI_RAW_RELEASE_URL_TEMPLATE = "https://github.com/Zwylair/BetterDiscordAutoInstaller/archive/refs/tags/{tag}.zip"
 BDAI_RELEASE_URL_TEMPLATE = "https://github.com/Zwylair/BetterDiscordAutoInstaller/releases/download/{tag}/BetterDiscordAutoInstaller-{tag}.zip"
-SETTINGS_PATH = "settings.json" if "PYCHARM_HOSTED" in os.environ else "../settings.json"
-GITHUB_TOKEN_FILE_PATH = "github_token" if "PYCHARM_HOSTED" in os.environ else "../github_token"
+SETTINGS_PATH = "settings.json" if "PYCHARM_HOSTED" in os.environ else os.path.join(APPDATA, "BetterDiscord", "settings.json")
+GITHUB_TOKEN_FILE_PATH = "github_token" if "PYCHARM_HOSTED" in os.environ else os.path.join(APPDATA, "BetterDiscord", "github_token")
 
 BD_LATEST_RELEASE_PAGE_URL = "https://github.com/rauenzi/BetterDiscordApp/releases/latest"
 BD_ASAR_URL = "https://github.com/rauenzi/BetterDiscordApp/releases/latest/download/betterdiscord.asar"

--- a/config/funcs.py
+++ b/config/funcs.py
@@ -25,6 +25,7 @@ def load_settings():
         config.DISCORD_PARENT_PATH = settings.get("discord_installed_path", config.DISCORD_PARENT_PATH)
         config.DISCORD_CANARY_PARENT_PATH = settings.get("discord_canary_installed_path", config.DISCORD_CANARY_PARENT_PATH)
         config.DISCORD_PTB_PARENT_PATH = settings.get("discord_ptb_installed_path", config.DISCORD_PTB_PARENT_PATH)
+        config.DISCORD_LAUNCH_MINIMIZED = settings.get("discord_launch_minimized", config.DISCORD_LAUNCH_MINIMIZED)
         config.DISABLE_BDAI_AUTOUPDATE = settings.get("disable_bdai_autoupdate", config.DISABLE_BDAI_AUTOUPDATE)
         config.USE_BD_CI_RELEASES = settings.get("use_betterdiscord_ci_releases", config.USE_BD_CI_RELEASES)
         config.WORKFLOW_RUNS_LIMIT = settings.get("workflow_runs_limit", config.WORKFLOW_RUNS_LIMIT)
@@ -48,6 +49,7 @@ def dump_settings():
                 "discord_installed_path": config.DISCORD_PARENT_PATH,
                 "discord_canary_installed_path": config.DISCORD_CANARY_PARENT_PATH,
                 "discord_ptb_installed_path": config.DISCORD_PTB_PARENT_PATH,
+                "discord_launch_minimized": config.DISCORD_LAUNCH_MINIMIZED,
                 "disable_bdai_autoupdate": config.DISABLE_BDAI_AUTOUPDATE,
                 "use_betterdiscord_ci_releases": config.USE_BD_CI_RELEASES,
                 "workflow_runs_limit": config.WORKFLOW_RUNS_LIMIT,

--- a/config/settings.py
+++ b/config/settings.py
@@ -12,6 +12,7 @@ RERUN_DISCORD_EDITION: Optional[str] = config.DiscordEdition.STABLE.to_str()
 DISCORD_PARENT_PATH: Optional[str] = None
 DISCORD_CANARY_PARENT_PATH: Optional[str] = None
 DISCORD_PTB_PARENT_PATH: Optional[str] = None
+DISCORD_LAUNCH_MINIMIZED: bool = False
 LAST_INSTALLED_DISCORD_VERSION: Optional[str] = None
 LAST_INSTALLED_DISCORD_CANARY_VERSION: Optional[str] = None
 LAST_INSTALLED_DISCORD_PTB_VERSION: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "bdai"
+dynamic = ["version"]
+description = "BetterDiscordAutoInstaller automatically updates Discord, launches it and applies BetterDiscord"
+readme = "README.md"
+requires-python = ">=3.13"
+dependencies = [
+    "psutil~=5.9.7",
+    "pywin32>=310 ; sys_platform == 'win32'",
+    "requests~=2.32.3",
+]
+[dependency-groups]
+dev = ["cx-freeze>=8.3.0", "types-pywin32>=310 ; sys_platform == 'win32'"]
+[project.scripts]
+bdai = "main:main"
+# bdai-update = "updater:main"
+
+[project.gui-scripts]
+bdai-headless = "main:main" # This is useful on Windows to avoid a cmd popup
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+[tool.hatch.version]
+path = "config/constants.py"
+pattern = 'BDAI_SCRIPT_VERSION = "(?P<version>[^"]+)"'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 psutil~=5.9.7
 requests~=2.32.3
-winshell~=0.6
-pypiwin32==223
+pywin32==310 ; sys_platform == 'win32'
 cx-freeze

--- a/startup_manager.py
+++ b/startup_manager.py
@@ -17,15 +17,20 @@ def main():
 
     print(f"BetterDiscordAutoInstaller v{config.BDAI_SCRIPT_VERSION} (startup_manager)")
 
+    link_working_directory = os.path.dirname(__file__)
+    link_target = sys.executable
+    link_arguments = os.path.join(link_working_directory, "main.py")
+    uv_target = os.path.join(os.path.dirname(sys.executable), "bdai-headless.exe")
     if getattr(sys, "frozen", False):
         link_working_directory = os.path.dirname(sys.executable)
         link_working_directory = os.path.split(link_working_directory)[0]  # a/b/c/ -> a/b/
         link_target = os.path.join(link_working_directory, "updater.exe")
         link_arguments = "--run"
-    else:
-        link_working_directory = os.path.dirname(__file__)
-        link_target = sys.executable
-        link_arguments = os.path.join(link_working_directory, "main.py")
+    elif os.path.isfile(uv_target):
+        config.load_settings()
+        link_working_directory = config.DISCORD_PARENT_PATH
+        link_target = uv_target
+        link_arguments = ""
     link_path = os.path.join(
         os.getenv("appdata"),
         r"Microsoft\Windows\Start Menu\Programs\Startup\BetterDiscordAutoInstaller.lnk"

--- a/startup_manager.py
+++ b/startup_manager.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import winshell
+from win32com.client import Dispatch
 
 import config
 
@@ -47,11 +47,13 @@ def main():
             break
         elif command == "1":
             try:
-                with winshell.shortcut(link_path) as link:
-                    link.path = link_target
-                    link.arguments = link_arguments
-                    link.working_directory = link_working_directory
-                    link.description = f"BetterDiscordAutoInstaller v{config.BDAI_SCRIPT_VERSION}"
+                shell = Dispatch("WScript.Shell")
+                link = shell.CreateShortCut(link_path)
+                link.TargetPath = link_target
+                link.Arguments = link_arguments
+                link.WorkingDirectory = link_working_directory
+                link.Description = f"BetterDiscordAutoInstaller v{config.BDAI_SCRIPT_VERSION}"
+                link.save()
                 print(".lnk file of the BetterDiscordAutoInstaller was added to startup.")
 
             except PermissionError:

--- a/utils/discord.py
+++ b/utils/discord.py
@@ -53,6 +53,7 @@ def start_discord(edition: config.DiscordEdition, discord_parent_path: str):
         raise FileNotFoundError(f"Update.exe not found in: {discord_parent_path}")
 
     command = f'"{update_exe}" --processStart {executable_name}'
+    command += " --process-start-args --start-minimized" if config.DISCORD_LAUNCH_MINIMIZED else ""
     logger.info(f"Starting Discord using command: {command}")
     subprocess.Popen(command, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 


### PR DESCRIPTION
- Added a setting to launch Discord minimized
- Moved `settings.json` location from relative path to the BetterDiscord folder in AppData for consistency with different run methods
  - Bumped minor version instead of patch due to this
- Add [UV](https://docs.astral.sh/uv/) as Install/Run method
  - `startup_manager` will create a shortcut to the headless (no console window) executable if available
  - Will log to `bdai.log` in settings folder instead of stdout if running headless