### PR TITLE
Validate BetterDiscord .asar before use

### DIFF
--- a/config/constants.py
+++ b/config/constants.py
@@ -14,6 +14,7 @@ SETTINGS_PATH = "settings.json" if "PYCHARM_HOSTED" in os.environ else "../setti
 GITHUB_TOKEN_FILE_PATH = "github_token" if "PYCHARM_HOSTED" in os.environ else "../github_token"
 
 BD_LATEST_RELEASE_PAGE_URL = "https://github.com/rauenzi/BetterDiscordApp/releases/latest"
+BD_RELEASE_API_URL = "https://api.github.com/repos/rauenzi/BetterDiscordApp/releases/latest"
 BD_ASAR_URL = "https://github.com/rauenzi/BetterDiscordApp/releases/latest/download/betterdiscord.asar"
 BD_ASAR_PATH = os.path.join(APPDATA, "BetterDiscord", "data", "betterdiscord.asar")
 BD_CI_ASAR_PATH = os.path.join(APPDATA, "BetterDiscord", "data", "betterdiscord-ci.asar")

--- a/utils/betterdiscord.py
+++ b/utils/betterdiscord.py
@@ -1,6 +1,8 @@
 import os
 import glob
+import hashlib
 import logging
+import time
 
 import requests
 
@@ -42,6 +44,62 @@ def is_bd_injected(discord_path: str, is_ci: bool) -> bool:
     return f'require("{get_asar_path(is_ci)}");' in content
 
 
+def _fetch_bd_stable_digest() -> str | None:
+    """GET latest BetterDiscord.asar checksum"""
+    try:
+        resp = requests.get(config.BD_RELEASE_API_URL, timeout=5)
+        resp.raise_for_status()
+        assets = resp.json().get("assets", [])
+        for asset in assets:
+            if asset.get("name") == "betterdiscord.asar":
+                digest = asset.get("digest", "")
+                if digest.startswith("sha256:"):
+                    return digest[len("sha256:"):]
+        logger.error("betterdiscord.asar asset or digest not found in release API response.")
+    except Exception as e:
+        logger.error(f"Failed to fetch release digest: {e}")
+    return None
+
+
+def _download_bd_stable_asar(dest_path: str, max_retries: int = 3) -> bool:
+    expected_digest = _fetch_bd_stable_digest() # Get .asar checksum
+
+    # Fail if unable to get checksum
+    if not expected_digest:
+        return False
+
+    tmp_path = dest_path + ".tmp"
+
+    for attempt in range(1, max_retries + 1):
+        try:
+            logger.info(f"Downloading BetterDiscord Stable asar (attempt {attempt}/{max_retries})...")
+            response = requests.get(config.BD_ASAR_URL, timeout=30)
+            response.raise_for_status()
+
+            # Compile and compare checksum
+            actual_digest = hashlib.sha256(response.content).hexdigest()
+            if actual_digest != expected_digest:
+                raise requests.exceptions.RequestException(
+                    f"SHA256 mismatch (attempt {attempt}): expected {expected_digest}, got {actual_digest}"
+                )
+
+            # Write to .tmp then swap to dest_path so the used .asar is never left half written
+            # that would cause Discord to crash on startup
+            with open(tmp_path, "wb") as f:
+                f.write(response.content)
+            os.replace(tmp_path, dest_path)
+            logger.info("BetterDiscord Stable asar downloaded and verified successfully.")
+            return True
+
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Download error (attempt {attempt}): {e}")
+            if attempt < max_retries:
+                time.sleep(2 ** (attempt - 1))
+
+    logger.error(f"Failed to download BetterDiscord Stable asar after {max_retries} attempts.")
+    return False
+
+
 def update_bd_asar_only(is_ci: bool):
     if is_ci:
         if update_bd_ci_asar():
@@ -53,15 +111,9 @@ def update_bd_asar_only(is_ci: bool):
 
     os.makedirs(os.path.dirname(config.BD_ASAR_PATH), exist_ok=True)
 
-    try:
-        logger.info("Downloading BetterDiscord Stable asar...")
-        response = requests.get(config.BD_ASAR_URL)
-        with open(config.BD_ASAR_PATH, "wb") as f:
-            f.write(response.content)
-        logger.info("BetterDiscord Stable asar downloaded successfully.")
-
-    except requests.exceptions.ConnectionError:
-        logger.error("Failed to download BetterDiscord Stable asar.")
+    if not _download_bd_stable_asar(config.BD_ASAR_PATH):
+        logger.error("BetterDiscord Stable asar update failed.")
+        return
 
     config.LAST_INSTALLED_BD_VERSION = fetch_latest_bd_release()
     config.dump_settings()


### PR DESCRIPTION
## What changed

- **`config/constants.py`** — added `BD_RELEASE_API_URL` pointing to the GitHub releases API for BetterDiscord
- **`utils/betterdiscord.py`** — replaced the bare `requests.get` + write in `update_bd_asar_only` with two new helpers:
  - `_fetch_bd_stable_digest()` — fetches the SHA256 digest/checksum with the GitHub releases API
  - `_download_bd_stable_asar()` — downloads the asar, verifies SHA256, writes atomically to dest_path.tmp, then `os.replace` to dest_temp(this assures no write interrups can cause erros) retries up to 3x 


## Why

The previous code did a raw `requests.get` and blindly wrote whatever bytes came back to disk. If GitHub hit a rate limit or the network failed mid download the corrupted file would be saved as `betterdiscord.asar` causing Discord to crash on every startup until manually fixed. 


## How it works

1. Fetches the latest BetterDiscord  .asar checksum via GitHub API
2. Downloads the latest .asar
3. Computes SHA256 checksum of downloaded asar and compares; mismatch raises `RequestException` and triggers a retry
4. On success, write to `dest.tmp` then `os.replace` atomically so the live asar is never left half-written

------------------------------------------------------------------------

### Test in actual environment:


> ```
> The test was done by changing "last_installed_betterdiscord_version": "v1.13.12" to "v1.13.11" in settings.json
>
> (2026-04-26 15:05:36,899) BetterDiscordAutoInstaller v1.5.0
> (2026-04-26 15:05:36,899) Checking for BetterDiscordAutoInstaller updates...
> (2026-04-26 15:05:37,939) BetterDiscordAutoInstaller is up to date.
> 
> (2026-04-26 15:05:37,940) Retrieving Discord installation folder...
> (2026-04-26 15:05:37,940) Checking for BetterDiscord updates...
> (2026-04-26 15:05:37,940) Fetching latest BetterDiscord Stable version.
> (2026-04-26 15:05:39,170)
> (2026-04-26 15:05:39,170) Processing Discord installation: C:\Users\admin\AppData\Local\Discord
> (2026-04-26 15:05:39,188)
> (2026-04-26 15:05:39,188) Killing any running Discord processes...
> (2026-04-26 15:05:39,199) Killing process: Discord.exe (PID: 1036)
> (2026-04-26 15:05:39,275) Killing process: Discord.exe (PID: 3152)
> (2026-04-26 15:05:39,490) Killing process: Discord.exe (PID: 14404)
> (2026-04-26 15:05:39,498) Killing process: Discord.exe (PID: 17168)
> (2026-04-26 15:05:39,506) Killing process: Discord.exe (PID: 19932)
> (2026-04-26 15:05:39,559) Killing process: Discord.exe (PID: 33324)
> (2026-04-26 15:05:41,568)
> (2026-04-26 15:05:41,568) BetterDiscord Stable has a new version, updating asar only.
> (2026-04-26 15:05:42,315) Downloading BetterDiscord Stable asar (attempt 1/3)...
> (2026-04-26 15:05:43,977) BetterDiscord Stable asar downloaded and verified successfully.
> (2026-04-26 15:05:43,979) Fetching latest BetterDiscord Stable version.
> (2026-04-26 15:05:44,367)
> (2026-04-26 15:05:44,367) Restarting Discord...
> (2026-04-26 15:05:44,368) Starting Discord from C:\Users\admin\AppData\Local\Discord...
> (2026-04-26 15:05:44,368) Starting Discord using command: "C:\Users\admin\AppData\Local\Discord\Update.exe" --processStart Discord.exe
> (2026-04-26 15:05:44,374)
> (2026-04-26 15:05:44,374) Installing YABDP4Nitro plugin...
> (2026-04-26 15:05:44,374) Plugin YABDP4Nitro already exists.
> (2026-04-26 15:05:44,375)
> (2026-04-26 15:05:44,375) Installation complete. Exiting in 3 seconds...
> ```